### PR TITLE
Another way to implement PawnColumnDef insertion and have better compatibility.

### DIFF
--- a/Assets/Defs/PawnColumnDefs.xml
+++ b/Assets/Defs/PawnColumnDefs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <PawnColumnDef>
+    <defName>DutyTally_Workload</defName>
+    <label>Workload</label>
+    <workerClass>mrclrchtr.DutyTally.Source.PawnColumnWorkerWorkload</workerClass>
+    <sortable>true</sortable>
+    <headerTip>How busy this pawn is. Can be a simple job count or weighted by priority. The weighting method and range can be configured in the mod settings.</headerTip>
+    <width>70</width>
+  </PawnColumnDef>
+
+</Defs>

--- a/Assets/Languages/ChineseSimplified/DefInjected/PawnColumnDef/PawnColumnDefs.xml
+++ b/Assets/Languages/ChineseSimplified/DefInjected/PawnColumnDef/PawnColumnDefs.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+
+  <DutyTally_Workload.label>工作负载</DutyTally_Workload.label>
+  <DutyTally_Workload.headerTip>该殖民者有多忙。可以是简单的工作数量，也可以根据优先级加权计算。加权方法和范围可在模组设置中进行配置。</DutyTally_Workload.headerTip>
+
+</LanguageData>

--- a/Assets/Languages/ChineseSimplified/Keyed/DutyTally.xml
+++ b/Assets/Languages/ChineseSimplified/Keyed/DutyTally.xml
@@ -1,0 +1,11 @@
+﻿<LanguageData>
+	<DutyTally_IgnoreInvisibleWorkTypes>忽略隐藏的工作类型</DutyTally_IgnoreInvisibleWorkTypes>
+	<DutyTally_IgnoreInvisibleWorkTypesTip>勾选此项可在计算工作负载时忽略工作标签页中通常不可见的工作（如 Allow Tool 模组中的“杀死”）。</DutyTally_IgnoreInvisibleWorkTypesTip>
+	
+	<DutyTally_UseWeightedPriorities>按优先级评分</DutyTally_UseWeightedPriorities>
+	<DutyTally_UseWeightedPrioritiesTip>勾选此项可根据优先级对工作负载进行评分。具体的加权方式取决于下面“加权最大优先级”的设置。不勾选则表示使用简单的工作数量统计。</DutyTally_UseWeightedPrioritiesTip>
+	
+	<DutyTally_MaxPriorityForWeighting>加权最大优先级</DutyTally_MaxPriorityForWeighting>
+	<DutyTally_MaxPriorityForWeightingTip>设置需要应用加权的最大优先级数字（例如 1、2、3、4……）。从优先级 1 到该值将获得递减的权重（例如设置为 4 时，P1=3，P2=2，P3=1，P4=1）。权重计算方式为 Max(1, 设置值 - 优先级)。高于此值的优先级将统一视为权重 1。默认值为 4。</DutyTally_MaxPriorityForWeightingTip>
+</LanguageData>
+

--- a/Assets/Languages/English/DefInjected/PawnColumnDef/PawnColumnDefs.xml
+++ b/Assets/Languages/English/DefInjected/PawnColumnDef/PawnColumnDefs.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+  <!-- It is retained as a translation template, but in fact, English translation is not required. It has been defined in def -->
+
+  <DutyTally_Workload.label>Workload</DutyTally_Workload.label>
+  <DutyTally_Workload.headerTip>How busy this pawn is. Can be a simple job count or weighted by priority. The weighting method and range can be configured in the mod settings.</DutyTally_Workload.headerTip>
+
+</LanguageData>

--- a/Assets/Languages/English/Keyed/DutyTally.xml
+++ b/Assets/Languages/English/Keyed/DutyTally.xml
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
-	<DutyTally_Workload>Workload</DutyTally_Workload>
-	<DutyTally_WorkloadTip>How busy this pawn is. Can be a simple job count or weighted by priority. The weighting method and range can be configured in the mod settings.</DutyTally_WorkloadTip>
 	<DutyTally_IgnoreInvisibleWorkTypes>Ignore hidden jobs</DutyTally_IgnoreInvisibleWorkTypes>
 	<DutyTally_IgnoreInvisibleWorkTypesTip>Tick this box to ignore jobs you don't normally see in the work tab (like 'Finish Off' from Allow Tool) when figuring out the workload.</DutyTally_IgnoreInvisibleWorkTypesTip>
 	<DutyTally_UseWeightedPriorities>Score by priority</DutyTally_UseWeightedPriorities>

--- a/Assets/Languages/German (Deutsch)/DefInjected/PawnColumnDef/PawnColumnDefs.xml
+++ b/Assets/Languages/German (Deutsch)/DefInjected/PawnColumnDef/PawnColumnDefs.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+
+  <DutyTally_Workload.label>Arbeitslast</DutyTally_Workload.label>
+  <DutyTally_Workload.headerTip>Zeigt, wie beschäftigt dieser Kolonist ist. Kann eine einfache Job-Zählung sein oder nach Priorität gewichtet werden. Die Gewichtungsmethode und der Bereich können in den Mod-Einstellungen konfiguriert werden.</DutyTally_Workload.headerTip>
+
+</LanguageData>

--- a/Assets/Languages/German (Deutsch)/Keyed/DutyTally.xml
+++ b/Assets/Languages/German (Deutsch)/Keyed/DutyTally.xml
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
-	<DutyTally_Workload>Arbeitslast</DutyTally_Workload>
-	<DutyTally_WorkloadTip>Zeigt, wie beschäftigt dieser Kolonist ist. Kann eine einfache Job-Zählung sein oder nach Priorität gewichtet werden. Die Gewichtungsmethode und der Bereich können in den Mod-Einstellungen konfiguriert werden.</DutyTally_WorkloadTip>
 	<DutyTally_IgnoreInvisibleWorkTypes>Versteckte Jobs ignorieren</DutyTally_IgnoreInvisibleWorkTypes>
 	<DutyTally_IgnoreInvisibleWorkTypesTip>Setz hier ein Häkchen, um Jobs zu ignorieren, die du normalerweise nicht im Arbeitsreiter siehst (z.B. 'Finish Off' von Allow Tool), wenn die Arbeitslast ermittelt wird.</DutyTally_IgnoreInvisibleWorkTypesTip>
 	<DutyTally_UseWeightedPriorities>Nach Priorität bewerten</DutyTally_UseWeightedPriorities>

--- a/Assets/Patches/PawnTableDef.xml
+++ b/Assets/Patches/PawnTableDef.xml
@@ -2,7 +2,7 @@
 <Patch>
     <Operation Class="PatchOperationInsert">
         <xpath>/Defs/PawnTableDef[defName="Work"]/columns/li[text()="RemainingSpace"]</xpath>
-        <order>Prepend</order>
+        <order>Append</order>
         <value>
             <li>DutyTally_Workload</li>
         </value>

--- a/Assets/Patches/PawnTableDef.xml
+++ b/Assets/Patches/PawnTableDef.xml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationInsert">
+        <xpath>/Defs/PawnTableDef[defName="Work"]/columns/li[text()="RemainingSpace"]</xpath>
+        <order>Prepend</order>
+        <value>
+            <li>DutyTally_Workload</li>
+        </value>
+    </Operation>
+</Patch>

--- a/BuildScript.ps1
+++ b/BuildScript.ps1
@@ -8,10 +8,10 @@ $buildOutput = Join-Path -Path $buildOutputBase -ChildPath "DutyTally" # .\Build
 # *** IMPORTANT: Do NOT include "Assemblies" in this list ***
 $assetFoldersToCleanAndCopy = @(
     "About",
-    "Languages"
-#     "Defs",       # Add if you have Defs
+    "Languages",
+    "Defs",
+    "Patches"
 #     "Textures",   # Add if you have Textures
-#     "Patches"     # Add if you have Patches
     # Add any other folders like "Sounds", etc. that originate from .\Assets
 )
 

--- a/DutyTally.csproj
+++ b/DutyTally.csproj
@@ -36,9 +36,6 @@
 
     <ItemGroup>
         <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4409"/>
-        <PackageReference Include="Lib.Harmony" Version="2.3.6">
-            <ExcludeAssets>runtime</ExcludeAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Duty Tally
 
 <p align="center">
-  <img src="About/Preview.png" alt="Duty Tally Logo" width="200"/>
+  <img src="Assets/About/Preview.png" alt="Duty Tally Logo" width="200"/>
 </p>
 
 ## Overview


### PR DESCRIPTION
Fix README.md img url error.
When the Grouping by column values setting item in the Grouped Pawns Lists mod is enabled, an NRE is caused because the PawnColumnDef named DutyTally_Workload is not found.
Secondly, some mods (for example: Achtung!) have the ability to dynamically add WorkType, so the static field AllWorkTypes is removed.